### PR TITLE
adds testing for [:meta] data

### DIFF
--- a/spec/requests/api/v1/posters/poster_request_spec.rb
+++ b/spec/requests/api/v1/posters/poster_request_spec.rb
@@ -37,6 +37,9 @@ describe "posters API" do
 
 		expect(posters[:data].count).to eq(3)
 
+		expect(posters[:meta]).to be_present
+		expect(posters[:meta][:count]).to eq(3)
+
 		posters[:data].each do |poster|
 			expect(poster[:id].to_i).to be_an(Integer)
 


### PR DESCRIPTION
Adds testing for recently added `options` hash, and `[:meta]` hash. Thereby making our index testing more complete and robust.